### PR TITLE
Removed Open Bool from Market

### DIFF
--- a/RoboticonColony/Assets/Code/Market.cs
+++ b/RoboticonColony/Assets/Code/Market.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 sealed public class Market
 {
     public Inventory Stock { get; private set; }
-    public bool Open { get; private set; }
 
     private Dictionary<ItemType, int> buyprice;
     private Dictionary<ItemType, int> sellprice;


### PR DESCRIPTION
#30 Remove Mention of Open withing Market and Market Testing

All mentions of Open within the market class, market test class and all others have been removed
(There was only one mention)
When merging in the future be careful to remove any further mention of it.