### PR TITLE
Fixed MaxWillBuy Function

### DIFF
--- a/RoboticonColony/Assets/Code/Market.cs
+++ b/RoboticonColony/Assets/Code/Market.cs
@@ -208,28 +208,18 @@ sealed public class Market
     /// <returns>An int which represents the maximum number of the specified type of item that the market will buy.</returns>
     public int MaxWillBuy(ItemType typeToBeBought)
     {
-        if (Stock.Money - (GetBuyPrice(typeToBeBought) * 10) > 0)
+        if (Stock.Money - (GetSellPrice(typeToBeBought) * 10) > 0)
         {
-            if (Stock.GetItemAmount(typeToBeBought) >= 10)
-            {
-                return 10;
-            }
-            else
-            {
-                return Stock.GetItemAmount(typeToBeBought);
-            }
-
+            return 10;
         }
         else
         {
             int moneyAvailable = Stock.Money;
-            int quantityAvailable = Stock.GetItemAmount(typeToBeBought);
             int quantity = 0;
-            while ((moneyAvailable > 0) && quantityAvailable > 0)
+            while (moneyAvailable > 0)
             {
-                moneyAvailable -= GetBuyPrice(typeToBeBought);
+                moneyAvailable -= GetSellPrice(typeToBeBought);
                 quantity += 1;
-                quantityAvailable -= 1;
             }
             return quantity;
         }


### PR DESCRIPTION
Function was broken, used to take into account current stock for some odd reason, if stock was 0, the item type would not be bought.
Also the function was using GetBuyPrice, which is the price of items bought from the market.
Now uses GetSellPrice, which is the price of items sold to the market.